### PR TITLE
bootcontrol: return error if set active for partitions fails

### DIFF
--- a/boot_control.cpp
+++ b/boot_control.cpp
@@ -560,7 +560,10 @@ int set_active_boot_slot(struct boot_control_module *module, unsigned slot)
 	for (map_iter = ptn_map.begin(); map_iter != ptn_map.end(); map_iter++){
 		if (map_iter->second.size() < 1)
 			continue;
-		boot_ctl_set_active_slot_for_partitions(map_iter->second, slot);
+		if (boot_ctl_set_active_slot_for_partitions(map_iter->second, slot)) {
+			ALOGE("%s: Failed to set active slot for partitions ", __func__);;
+			goto error;
+		}
 	}
 	if (is_ufs) {
 		if (!strncmp(slot_suffix_arr[slot], AB_SLOT_A_SUFFIX,


### PR DESCRIPTION
Do not continue in case of an error setting active slot for all
partitions. Otherwise, boot LUN will be changed causing XBL to be read
from the new slot but other parts of the bootloader will be read from
old slot. This may cause the bootloader to crash and device will be
bricked

Bug: 77969086
Test: bootctl set-active-boot-slot 0
Change-Id: Ief029f314d3b1197e43b6e85ac78aba9761cf736
Signed-off-by: Fernando Lugo <flugo@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonyxperiadev/hardware-qcom-bootctrl/1)
<!-- Reviewable:end -->
